### PR TITLE
Adding vdisk command

### DIFF
--- a/debian/.bashrc
+++ b/debian/.bashrc
@@ -174,6 +174,19 @@ extract () {
   fi
 }
 
+# Create a .vmdk file (disk drive format for VirtualBox), linked to
+# the physical disk specified in second parameter
+
+vdisk()
+{
+	if [ $# == 2 ]
+	then
+		VBoxManage internalcommands createrawvmdk -filename "$1.vmdk" -rawdisk /dev/$2
+	else
+		echo "Usage: vdisk <filename> <disk_id>"
+	fi
+}
+
 #Defined here because it can be used in welcome() function
 #Month calendar with current day in red
 alias c='var=$(cal); echo "${var/$(date +%-d)/$(echo -e "\033[1;31m$(date +%-d)\033[0m")}"'

--- a/debian/.bashrc
+++ b/debian/.bashrc
@@ -182,6 +182,7 @@ vdisk()
 	if [ $# == 2 ]
 	then
 		VBoxManage internalcommands createrawvmdk -filename "$1.vmdk" -rawdisk /dev/$2
+		echo "Please check unmounting the disk $2."
 	else
 		echo "Usage: vdisk <filename> <disk_id>"
 	fi

--- a/debian/.bashrc
+++ b/debian/.bashrc
@@ -175,7 +175,7 @@ extract () {
 }
 
 # Create a .vmdk file (disk drive format for VirtualBox), linked to
-# the physical disk specified in second parameter
+# the physical disk specified in second parameter. Need root (to be in /var/root/.bashrc too)
 
 vdisk()
 {


### PR DESCRIPTION
vdisk() is a powerful command to use physical disks as virtual disks into VirtualBox. This command perform a VBox compatible link to a hard disk. Be careful, the disk must be unmount (BEFORE AND ?) AFTER typing the command on the host system to prevent double writing (virtual and host) together. That can entrain damages on the physical disk.

Tested on Mac OS X Sierra, normally work on Debian and others.